### PR TITLE
Fix to make IDs required for text input & text area

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -62,7 +62,13 @@ Child.args = {
   id: "checkbox-item-child",
   name: "checkbox",
   value: "checkbox-item",
-  children: [<TextArea label="Text input label" fieldName="text-input" />],
+  children: [
+    <TextArea
+      id="test-input-1"
+      label="Text input label"
+      fieldName="text-input"
+    />,
+  ],
 };
 
 export const MultipleChildren = Template.bind({});
@@ -79,7 +85,11 @@ MultipleChildren.args = {
       name="checkbox-children"
       value="child-1"
       children={[
-        <TextArea label="Child 1's TextArea" fieldName="child-1-textArea" />,
+        <TextArea
+          id="test-input-2"
+          label="Child 1's TextArea"
+          fieldName="child-1-textArea"
+        />,
       ]}
     />,
     <Checkbox
@@ -89,7 +99,11 @@ MultipleChildren.args = {
       name="checkbox-children"
       value="child-2"
       children={[
-        <TextArea label="Child 2's TextArea" fieldName="child-2-textArea" />,
+        <TextArea
+          id="test-input-3"
+          label="Child 2's TextArea"
+          fieldName="child-2-textArea"
+        />,
         <Checkbox
           checked={true}
           id="checkbox-item-child-3"
@@ -98,6 +112,7 @@ MultipleChildren.args = {
           value="child-2-child"
           children={[
             <TextArea
+              id="test-input-4"
               label="Child 2's Child TextArea"
               fieldName="child-2-child-textArea"
             />,

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -64,6 +64,7 @@ Child.args = {
   value: "checkbox-item",
   children: [
     <TextArea
+      key="text-input-1"
       id="test-input-1"
       label="Text input label"
       fieldName="text-input"
@@ -87,6 +88,7 @@ MultipleChildren.args = {
       children={[
         <TextArea
           id="test-input-2"
+          key="test-input-2"
           label="Child 1's TextArea"
           fieldName="child-1-textArea"
         />,
@@ -101,17 +103,20 @@ MultipleChildren.args = {
       children={[
         <TextArea
           id="test-input-3"
+          key="test-input-3"
           label="Child 2's TextArea"
           fieldName="child-2-textArea"
         />,
         <Checkbox
           checked={true}
           id="checkbox-item-child-3"
+          key="checkbox-item-child-3"
           label="Child 2's Child"
           name="second-child"
           value="child-2-child"
           children={[
             <TextArea
+              key="test-input-4"
               id="test-input-4"
               label="Child 2's Child TextArea"
               fieldName="child-2-child-textArea"

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -70,18 +70,21 @@ describe("Checkbox", () => {
         <form data-testid="test-form">
           <Checkbox
             id="checkbox-with-children"
+            key="checkbox-with-children"
             label="Checkbox with Children"
             name="checkbox"
             value="checkbox-with-children"
             children={[
               <Checkbox
                 id="child-1"
+                key="child-1"
                 label="Child 1"
                 name="checkbox-children"
                 value="child-1"
               />,
               <Checkbox
                 id="child-2"
+                key="child-2"
                 label="Child 2"
                 name="checkbox-children"
                 value="child-2"
@@ -133,7 +136,12 @@ describe("Checkbox", () => {
             name="checkbox"
             value="checkbox-with-children"
             children={[
-              <TextArea label="Child TextArea" fieldName="child-textArea" />,
+              <TextArea
+                key="textarea-child"
+                id="test-input-area"
+                label="Child TextArea"
+                fieldName="child-textArea"
+              />,
             ]}
           />
         </form>
@@ -246,6 +254,7 @@ describe("Checkbox", () => {
       const { container } = render(
         <Checkbox
           checked={true}
+          key="test1"
           id="checkbox-with-children"
           label="Checkbox with Children"
           name="checkbox"
@@ -266,6 +275,7 @@ describe("Checkbox", () => {
     it("renders tile Checkbox as expected", () => {
       const { container } = render(
         <Checkbox
+          key="test2"
           id="check-tile"
           isTile={true}
           label="Tile Checkbox"

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -265,6 +265,7 @@ describe("Checkbox", () => {
               label="Child 1"
               name="checkbox-children"
               value="child-1"
+              key="checkbox-item-child-1"
             />,
           ]}
         />

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -62,6 +62,7 @@ CharachterCount.args = {
   characterCountMessage: "Available remaining characters:",
   showCharacterCount: true,
   maxLength: 500,
+  id: "character-count-textarea",
 };
 
 RequiredAndError.args = {
@@ -69,15 +70,18 @@ RequiredAndError.args = {
   inputError: true,
   label: "Required Input Field",
   required: true,
+  id: "required-and-error-textarea",
 };
 
 Success.args = {
   label: "Field with Success Indicator",
   initialValue: "This is a good value!",
   inputSuccess: true,
+  id: "success-textarea",
 };
 
 InputFilter.args = {
   label: "This field only accepts a numerical input",
   inputFilter: /^-?\d*$/i,
+  id: "filter-textarea",
 };

--- a/src/components/TextArea/TextArea.test.tsx
+++ b/src/components/TextArea/TextArea.test.tsx
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  cleanAttributes,
-  screen,
-  render,
-  getByLabelText,
-  getByText,
-} from "../../test-setup";
+import { screen, render, getByLabelText, getByText } from "../../test-setup";
 import fireEvent from "@testing-library/user-event";
 import { TextArea } from "./TextArea";
 
@@ -184,7 +178,6 @@ describe("TextArea component", () => {
           fieldName="testing-textarea"
         />
       );
-      cleanAttributes(container, ["input-type-textarea"]);
       expect(container).toMatchSnapshot();
     });
     it("required and error", () => {
@@ -199,7 +192,6 @@ describe("TextArea component", () => {
           placeholder="Can you place this?"
         />
       );
-      cleanAttributes(container, ["input-type-textarea"]);
       expect(container).toMatchSnapshot();
     });
     it("success", () => {
@@ -211,7 +203,6 @@ describe("TextArea component", () => {
           inputSuccess
         />
       );
-      cleanAttributes(container, ["input-type-textarea"]);
       expect(container).toMatchSnapshot();
     });
   });

--- a/src/components/TextArea/TextArea.test.tsx
+++ b/src/components/TextArea/TextArea.test.tsx
@@ -17,6 +17,7 @@ describe("TextArea component", () => {
     beforeEach(() => {
       render(
         <TextArea
+          id="test-input-area"
           label="Testing TextArea"
           fieldName="testing-textarea"
           errorMessage={errorMessage}
@@ -57,6 +58,7 @@ describe("TextArea component", () => {
     it("should render with the character counter", () => {
       const { container } = render(
         <TextArea
+          id="test-input-area"
           label="Testing TextArea"
           fieldName="testing-textarea"
           showCharacterCount
@@ -72,6 +74,7 @@ describe("TextArea component", () => {
     it("should render character counter as a fraction", () => {
       const { container } = render(
         <TextArea
+          id="test-input-area"
           label="Testing TextArea"
           fieldName="testing-textarea"
           showCharacterCount
@@ -88,6 +91,7 @@ describe("TextArea component", () => {
     it("should render character counter with message", () => {
       const { container } = render(
         <TextArea
+          id="test-input-area"
           label="Testing TextArea"
           fieldName="testing-textarea"
           characterCountMessage="You have used:"
@@ -106,6 +110,7 @@ describe("TextArea component", () => {
   it("should add 'usa-focus' on focus'", () => {
     const { container } = render(
       <TextArea
+        id="test-input-area"
         label="Testing Input"
         fieldName="testing-input"
         errorMessage="Click me to unfocus input"
@@ -131,6 +136,7 @@ describe("TextArea component", () => {
     const errorMessage = "My name is Tom Riddle";
     render(
       <TextArea
+        id="test-input-area"
         label="Testing TextArea"
         fieldName="testing-textarea"
         errorMessage={errorMessage}
@@ -143,6 +149,7 @@ describe("TextArea component", () => {
   it("should be required", () => {
     render(
       <TextArea
+        id="test-input-area"
         label="Testing TextArea"
         fieldName="testing-textarea"
         required
@@ -157,6 +164,7 @@ describe("TextArea component", () => {
     const filter = new RegExp(/^-?\d*$/i);
     render(
       <TextArea
+        id="test-input-area"
         label="Testing TextArea"
         fieldName="testing-textarea"
         inputFilter={filter}
@@ -170,7 +178,11 @@ describe("TextArea component", () => {
   describe("compontent snapshots", () => {
     it("default", () => {
       const { container } = render(
-        <TextArea label="Testing TextArea" fieldName="testing-textarea" />
+        <TextArea
+          id="test-input-area"
+          label="Testing TextArea"
+          fieldName="testing-textarea"
+        />
       );
       cleanAttributes(container, ["input-type-textarea"]);
       expect(container).toMatchSnapshot();
@@ -179,6 +191,7 @@ describe("TextArea component", () => {
       const errorMessage = "My name is Tom Riddle";
       const { container } = render(
         <TextArea
+          id="test-input-area"
           label="Testing TextArea"
           fieldName="testing-textarea"
           errorMessage={errorMessage}
@@ -192,6 +205,7 @@ describe("TextArea component", () => {
     it("success", () => {
       const { container } = render(
         <TextArea
+          id="test-input-area"
           label="Testing TextArea"
           fieldName="testing-textarea"
           inputSuccess

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from "react";
-import { generateId } from "../../utils";
+import React, { useState } from "react";
 
 type IntrinsicElements = JSX.IntrinsicElements["textarea"];
 
@@ -7,6 +6,7 @@ interface Props extends IntrinsicElements {
   characterCountMessage?: string;
   errorMessage?: string;
   fieldName: string;
+  id: string;
   inputError?: boolean;
   inputFilter?: RegExp;
   inputSuccess?: boolean;
@@ -19,6 +19,7 @@ interface Props extends IntrinsicElements {
  * TextArea Component
  * @param {string}  label                   Field label.
  * @param {string}  fieldName               Name of the input field.
+ * @param {string}  id                      A unique identifier for the input.
  * @param {string}  [characterCountMessage] Sets a message preceding the character count when showCharacterCount === true.
  * @param {string}  [errorMessage]          Error message text displayed when inputError === true.
  * @param {boolean} [inputError]            Triggers error message and error styling.
@@ -33,6 +34,7 @@ export const TextArea: React.FC<Props> = ({
   fieldName,
   characterCountMessage,
   errorMessage,
+  id,
   inputError = false,
   inputFilter,
   inputSuccess = false,
@@ -43,11 +45,6 @@ export const TextArea: React.FC<Props> = ({
 }) => {
   const [focused, setFocused] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>("");
-  const [id, setId] = useState<number>(0);
-
-  useEffect(() => {
-    setId(generateId());
-  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (inputFilter && inputFilter.test(e.target.value)) {

--- a/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`TextArea component compontent snapshots default 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-textarea-test-input"
+      for="input-type-textarea-test-input-area"
     >
       Testing TextArea
     </label>
     <textarea
       aria-describedby=""
       class="usa-textarea"
-      id="input-type-textarea-test-input"
+      id="input-type-textarea-test-input-area"
       name="testing-textarea"
     />
   </div>
@@ -28,7 +28,7 @@ exports[`TextArea component compontent snapshots required and error 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-textarea-test-input"
+      for="input-type-textarea-test-input-area"
     >
       Testing TextArea
       <span
@@ -40,7 +40,7 @@ exports[`TextArea component compontent snapshots required and error 1`] = `
     <textarea
       aria-describedby=""
       class="usa-textarea"
-      id="input-type-textarea-test-input"
+      id="input-type-textarea-test-input-area"
       name="testing-textarea"
       placeholder="Can you place this?"
       required=""
@@ -56,14 +56,14 @@ exports[`TextArea component compontent snapshots success 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-textarea-test-input"
+      for="input-type-textarea-test-input-area"
     >
       Testing TextArea
     </label>
     <textarea
       aria-describedby=""
       class="usa-textarea usa-input--success"
-      id="input-type-textarea-test-input"
+      id="input-type-textarea-test-input-area"
       name="testing-textarea"
     />
   </div>

--- a/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`TextArea component compontent snapshots default 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-textarea"
+      for="input-type-textarea-test-input"
     >
       Testing TextArea
     </label>
     <textarea
       aria-describedby=""
       class="usa-textarea"
-      id="input-type-textarea"
+      id="input-type-textarea-test-input"
       name="testing-textarea"
     />
   </div>
@@ -28,7 +28,7 @@ exports[`TextArea component compontent snapshots required and error 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-textarea"
+      for="input-type-textarea-test-input"
     >
       Testing TextArea
       <span
@@ -40,7 +40,7 @@ exports[`TextArea component compontent snapshots required and error 1`] = `
     <textarea
       aria-describedby=""
       class="usa-textarea"
-      id="input-type-textarea"
+      id="input-type-textarea-test-input"
       name="testing-textarea"
       placeholder="Can you place this?"
       required=""
@@ -56,14 +56,14 @@ exports[`TextArea component compontent snapshots success 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-textarea"
+      for="input-type-textarea-test-input"
     >
       Testing TextArea
     </label>
     <textarea
       aria-describedby=""
       class="usa-textarea usa-input--success"
-      id="input-type-textarea"
+      id="input-type-textarea-test-input"
       name="testing-textarea"
     />
   </div>

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -70,9 +70,11 @@ RequiredAndError.args = {
   inputError: true,
   label: "Required Input Field",
   required: true,
+  id: "required-and-error-textarea",
 };
 
 Success.args = {
   label: "Field with Success Indicator",
   inputSuccess: true,
+  id: "success-textarea",
 };

--- a/src/components/TextInput/TextInput.test.tsx
+++ b/src/components/TextInput/TextInput.test.tsx
@@ -16,6 +16,7 @@ describe("TextInput component", () => {
     beforeEach(() => {
       render(
         <TextInput
+          id="test-input"
           label="Testing Input"
           fieldName="testing-input"
           errorMessage={errorMessage}
@@ -50,6 +51,7 @@ describe("TextInput component", () => {
     const errorMessage = "My name is Tom Riddle";
     render(
       <TextInput
+        id="test-input"
         label="Testing Input"
         fieldName="testing-input"
         errorMessage={errorMessage}
@@ -61,7 +63,12 @@ describe("TextInput component", () => {
 
   it("should be required", () => {
     render(
-      <TextInput label="Testing Input" fieldName="testing-input" required />
+      <TextInput
+        id="test-input"
+        label="Testing Input"
+        fieldName="testing-input"
+        required
+      />
     );
     const comp = screen.getByLabelText("Testing Input*");
     expect(comp).toBeInTheDocument();
@@ -72,6 +79,7 @@ describe("TextInput component", () => {
     const filter = new RegExp(/^-?\d*$/i);
     render(
       <TextInput
+        id="test-input"
         label="Testing Input"
         fieldName="testing-input"
         inputFilter={filter}
@@ -85,6 +93,7 @@ describe("TextInput component", () => {
   it("should add 'usa-focus' on focus'", () => {
     const { container } = render(
       <TextInput
+        id="test-input"
         label="Testing Input"
         fieldName="testing-input"
         errorMessage="Click me to unfocus input"
@@ -109,7 +118,11 @@ describe("TextInput component", () => {
   describe("compontent snapshots", () => {
     it("default", () => {
       const { container } = render(
-        <TextInput label="Testing Input" fieldName="testing-input" />
+        <TextInput
+          id="test-input"
+          label="Testing Input"
+          fieldName="testing-input"
+        />
       );
       cleanAttributes(container, ["input-type-text"]);
       expect(container).toMatchSnapshot();
@@ -119,6 +132,7 @@ describe("TextInput component", () => {
       const errorMessage = "My name is Tom Riddle";
       const { container } = render(
         <TextInput
+          id="test-input"
           label="Testing Input"
           fieldName="testing-input"
           errorMessage={errorMessage}
@@ -132,6 +146,7 @@ describe("TextInput component", () => {
     it("success", () => {
       const { container } = render(
         <TextInput
+          id="test-input"
           label="Testing Input"
           fieldName="testing-input"
           inputSuccess
@@ -144,6 +159,7 @@ describe("TextInput component", () => {
     it("prefix and suffix", () => {
       const { container } = render(
         <TextInput
+          id="test-input"
           label="Testing Input"
           fieldName="testing-input"
           prefix="$"

--- a/src/components/TextInput/TextInput.test.tsx
+++ b/src/components/TextInput/TextInput.test.tsx
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  cleanAttributes,
-  screen,
-  render,
-  getByLabelText,
-  getByText,
-} from "../../test-setup";
+import { screen, render, getByLabelText, getByText } from "../../test-setup";
 import fireEvent from "@testing-library/user-event";
 import { TextInput } from "./TextInput";
 
@@ -124,7 +118,6 @@ describe("TextInput component", () => {
           fieldName="testing-input"
         />
       );
-      cleanAttributes(container, ["input-type-text"]);
       expect(container).toMatchSnapshot();
     });
 
@@ -139,7 +132,6 @@ describe("TextInput component", () => {
           required
         />
       );
-      cleanAttributes(container, ["input-type-text"]);
       expect(container).toMatchSnapshot();
     });
 
@@ -152,7 +144,6 @@ describe("TextInput component", () => {
           inputSuccess
         />
       );
-      cleanAttributes(container, ["input-type-text"]);
       expect(container).toMatchSnapshot();
     });
 
@@ -166,7 +157,6 @@ describe("TextInput component", () => {
           suffix="lbs."
         />
       );
-      cleanAttributes(container, ["input-type-text"]);
       expect(container).toMatchSnapshot();
     });
   });

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from "react";
-import { generateId } from "../../utils";
+import React, { useState } from "react";
 
 type IntrinsicElements = JSX.IntrinsicElements["input"];
 
 interface Props extends IntrinsicElements {
   errorMessage?: string;
   fieldName: string;
+  id: string;
   inputError?: boolean;
   inputFilter?: RegExp;
   inputSuccess?: boolean;
@@ -18,6 +18,7 @@ interface Props extends IntrinsicElements {
  * TextInput Component
  * @param {string}  label          Field label.
  * @param {string}  fieldName      Name of the input field.
+ * @param {string}  id             A unique identifier for the input.
  * @param {string}  [errorMessage] Error message text displayed when inputError === true.
  * @param {boolean} [inputError]   Triggers error message and error styling.
  * @param {RegExp}  [inputFilter]  Used to limit input values. If a RegExp is not provided, all input types are allowed.
@@ -30,6 +31,7 @@ export const TextInput: React.FC<Props> = ({
   label,
   errorMessage,
   fieldName,
+  id,
   inputError = false,
   inputFilter,
   inputSuccess = false,
@@ -40,11 +42,6 @@ export const TextInput: React.FC<Props> = ({
 }) => {
   const [focused, setFocused] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>("");
-  const [id, setId] = useState<number>(0);
-
-  useEffect(() => {
-    setId(generateId());
-  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (inputFilter && inputFilter.test(e.target.value)) {

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`TextInput component compontent snapshots default 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-text"
+      for="input-type-text-test"
     >
       Testing Input
     </label>
@@ -17,7 +17,7 @@ exports[`TextInput component compontent snapshots default 1`] = `
       <input
         aria-describedby=""
         class="usa-input"
-        id="input-type-text"
+        id="input-type-text-test"
         name="testing-input"
         value=""
       />
@@ -33,7 +33,7 @@ exports[`TextInput component compontent snapshots prefix and suffix 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-text"
+      for="input-type-text-test"
     >
       Testing Input
     </label>
@@ -49,7 +49,7 @@ exports[`TextInput component compontent snapshots prefix and suffix 1`] = `
       <input
         aria-describedby=""
         class="usa-input"
-        id="input-type-text"
+        id="input-type-text-test"
         name="testing-input"
         value=""
       />
@@ -71,7 +71,7 @@ exports[`TextInput component compontent snapshots required and error 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-text"
+      for="input-type-text-test"
     >
       Testing Input
       <span
@@ -86,7 +86,7 @@ exports[`TextInput component compontent snapshots required and error 1`] = `
       <input
         aria-describedby=""
         class="usa-input"
-        id="input-type-text"
+        id="input-type-text-test"
         name="testing-input"
         required=""
         value=""
@@ -103,7 +103,7 @@ exports[`TextInput component compontent snapshots success 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-text"
+      for="input-type-text-test"
     >
       Testing Input
     </label>
@@ -113,7 +113,7 @@ exports[`TextInput component compontent snapshots success 1`] = `
       <input
         aria-describedby=""
         class="usa-input"
-        id="input-type-text"
+        id="input-type-text-test"
         name="testing-input"
         value=""
       />

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`TextInput component compontent snapshots default 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-text-test"
+      for="input-type-text-test-input"
     >
       Testing Input
     </label>
@@ -17,7 +17,7 @@ exports[`TextInput component compontent snapshots default 1`] = `
       <input
         aria-describedby=""
         class="usa-input"
-        id="input-type-text-test"
+        id="input-type-text-test-input"
         name="testing-input"
         value=""
       />
@@ -33,7 +33,7 @@ exports[`TextInput component compontent snapshots prefix and suffix 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-text-test"
+      for="input-type-text-test-input"
     >
       Testing Input
     </label>
@@ -49,7 +49,7 @@ exports[`TextInput component compontent snapshots prefix and suffix 1`] = `
       <input
         aria-describedby=""
         class="usa-input"
-        id="input-type-text-test"
+        id="input-type-text-test-input"
         name="testing-input"
         value=""
       />
@@ -71,7 +71,7 @@ exports[`TextInput component compontent snapshots required and error 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-text-test"
+      for="input-type-text-test-input"
     >
       Testing Input
       <span
@@ -86,7 +86,7 @@ exports[`TextInput component compontent snapshots required and error 1`] = `
       <input
         aria-describedby=""
         class="usa-input"
-        id="input-type-text-test"
+        id="input-type-text-test-input"
         name="testing-input"
         required=""
         value=""
@@ -103,7 +103,7 @@ exports[`TextInput component compontent snapshots success 1`] = `
   >
     <label
       class="usa-label"
-      for="input-type-text-test"
+      for="input-type-text-test-input"
     >
       Testing Input
     </label>
@@ -113,7 +113,7 @@ exports[`TextInput component compontent snapshots success 1`] = `
       <input
         aria-describedby=""
         class="usa-input"
-        id="input-type-text-test"
+        id="input-type-text-test-input"
         name="testing-input"
         value=""
       />

--- a/src/test-setup.tsx
+++ b/src/test-setup.tsx
@@ -31,28 +31,3 @@ export { customRender as render };
  * @param {HTMLElement} container The component to clean up.
  * @param {prefixes}      string[]  The reference substrings to leave alone.
  */
-export const cleanAttributes = (container: HTMLElement, prefixes: string[]) => {
-  const attributes = ["id", "for"];
-
-  const clean = (attr: string) => {
-    for (const prefix of prefixes) {
-      if (attr.includes(prefix)) {
-        const attrList = attr.split("-");
-        attrList.splice(-1);
-        return attrList.join("-");
-      }
-    }
-    return attr;
-  };
-
-  attributes.forEach((attr) => {
-    if (container.hasAttribute(attr)) {
-      const value = clean(container.getAttribute(attr)!);
-      container.setAttribute(attr, value);
-    }
-  });
-
-  Array.from(container.children).forEach((child) => {
-    cleanAttributes(child as HTMLElement, prefixes);
-  });
-};


### PR DESCRIPTION
## Purpose
- We've decided to make ids required for inputs.
- For keys key is not a property we can pass down the chain. If a consumer uses multiple components, they are responsible for providing keys to react

#### Pull Request Creator Checklist

- [x] It is documented what type of request this is.
- [x] There is a detailed description for the purpose of this PR.
- [x] This PR is in line with the intention of this Project
