### PR TITLE
Cleanup argTypes.defaultValue Warning

### DIFF
--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -3,37 +3,33 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { Typography } from "./Typography";
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: "USWDS/Base/Typography",
   component: Typography,
-  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  args: {
+    as: "p",
+    family: "sans",
+    size: "md",
+  },
   argTypes: {
+    as: {
+      description: "The type of component that will be rendered",
+    },
     family: {
-      defaultValue: "sans",
       description:
         "This is the font-family for the text that will be rendered.",
     },
     size: {
-      defaultValue: "xs",
       description: "This is the size of the text that will be rendered.",
-    },
-    as: {
-      defaultValue: "p",
-      description: "The type of component that will be rendered",
     },
   },
 } as ComponentMeta<typeof Typography>;
 
-// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template: ComponentStory<typeof Typography> = ({ children, ...rest }) => (
   <Typography {...rest}>{children}</Typography>
 );
 
 export const Standard = Template.bind({});
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
 Standard.args = {
   children: "Testing",
-  size: "md",
-  family: "sans",
 };


### PR DESCRIPTION
## Purpose

Created this branch to cleanup some of the warnings/errors we're seeing in the console.

## Type of Request

chore

## Approach

`argTypes.defaultValue` **Warning**

This warning was coming from `argTypes.defaultValue` being used in the `Typography` component stories. Updated to use the new pattern. This got rid of the warning.

![Screen Shot 2022-08-10 at 9 07 40 AM](https://user-images.githubusercontent.com/22647707/183914785-e949d74d-7f16-44b6-9716-183f5569a74f.png)

`ReactDOM.render` **Error**

We have no control over this error. The error is being caused by Storybook. See [this comment](https://github.com/storybookjs/storybook/issues/17831#issuecomment-1205173409) on a GitHub Issue related to the topic.

In short, we are building React 18 components. They are being rendered with the React 18 API. Storybook is built using React and is still using version 17. Storybook is rendering components as we expect and we are given the full functionality of React 18. 

![Screen Shot 2022-08-10 at 9 33 40 AM](https://user-images.githubusercontent.com/22647707/183915254-b4f84172-d311-4cfc-a245-9277ea1544d0.png)


#### Pull Request Creator Checklist

- [X] It is documented what type of request this is.
- [X] There is a detailed description for the purpose of this PR.
- [X] This PR is in line with the intention of this Project
