### PR TITLE
Create USWDSDecorator

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
 import "../src/assets/css/styles.css";
-import "../src/assets/js/uswds.min";
-import "../src/assets/js/uswds-init.min";
-import "../src/assets/theme/styles.scss"
+import "../src/assets/theme/styles.scss";
+
+import "../src/assets/js/uswds-init.min.js";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Dropdown } from "./Dropdown";
+import { USWDSDecorator } from "../../utils";
 import data from "./data.json";
 
 export default {
   title: "COMPONENTS/Dropdown",
   component: Dropdown,
+  decorators: [...USWDSDecorator],
   args: {
     data,
   },

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,3 +1,33 @@
+import React, { useEffect, useState } from "react";
+
 export const generateId = (digits: number = 6): number => {
   return Math.trunc(Math.random() * Math.pow(10, digits));
 };
+
+/**
+ * Standard Storybook Decorators
+ *
+ * This decorator manually injects the `uswds.js` script in the component story on load. Adding this
+ * script anywhere else seems to cause issues due to the way Storybook is rendering the components.
+ *
+ * At present, importing this file in preview, preview-head, preview-body, or in component code does
+ * not work.
+ */
+export const USWDSDecorator = [
+  (Story: any) => {
+    const [isLoaded, setIsLoaded] = useState(false);
+    useEffect(() => {
+      const script = document.createElement("script");
+      script.onload = () => {
+        setIsLoaded(true);
+      };
+      script.src = "/assets/js/uswds.js";
+      document.body.appendChild(script);
+      return () => {
+        // clean up effects of script here
+      };
+    }, []);
+
+    return isLoaded ? <Story /> : <div>Loading...</div>;
+  },
+];


### PR DESCRIPTION
## Purpose

Create a decorator that injects the `uswds.js` file on Storybook stories.

## Type of Request

bug

## Approach

For components that will require the `uswds.js` file to function correctly, the only obvious way for us to get the script loaded on the page correctly is to inject it at the Storybook story level as a decorator. This decorator creates a `<script>` with `uswds.js` as the source and adds it to the document in a `useEffect`.

This decorator is exported and can easily be accessed from the `utils.tsx` file. 

#### Pull Request Creator Checklist

- [X] It is documented what type of request this is.
- [X] There is a detailed description for the purpose of this PR.
- [X] This PR is in line with the intention of this Project
