### PR TITLE
[Oy2-19482] Create Card Choice Component

### DIFF
--- a/src/assets/theme/_uswds-theme-custom-styles.scss
+++ b/src/assets/theme/_uswds-theme-custom-styles.scss
@@ -1,25 +1,6 @@
-/*
-* * * * * ==============================
-* * * * * ==============================
-* * * * * ==============================
-* * * * * ==============================
-========================================
-========================================
-========================================
-----------------------------------------
-USWDS THEME CUSTOM STYLES
-----------------------------------------
-!! Copy this file to your project's
-   sass root. Don't edit the version
-   in node_modules.
-----------------------------------------
-Custom project SASS goes here.
-
-i.e.
-@include u-padding-right('05');
-----------------------------------------
-*/
 @forward "../../components/Button/Button.scss";
+@forward "../../components/CardChoice/CardChoice.scss";
+@forward "../../components/CardChoice/CardChoiceGroup.scss";
 @forward "../../components/Checkbox/Checkbox.scss";
 @forward "../../components/Footer/Footer.scss";
 @forward "../../components/Header/ActionsMenu.scss";

--- a/src/components/CardChoice/CardChoice.scss
+++ b/src/components/CardChoice/CardChoice.scss
@@ -5,6 +5,7 @@
   flex-direction: row;
   justify-content: space-between;
   padding: 26px;
+  text-decoration: none;
   &.card-choice--bordered {
     border: solid 2px c.$gray-lighter;
     border-top: none;
@@ -16,11 +17,15 @@
   &:hover {
     background-color: c.$primary-alt-lightest;
     border: solid 2px c.$primary-alt-dark;
-    cursor: pointer;
     padding: 24px;
     &.card-choice--bordered {
       margin-top: -2px;
     }
+  }
+  &:focus {
+    outline: 0.25rem solid #2491ff;
+    outline-offset: 0;
+    position: relative;
   }
   .content {
     line-height: 24px;
@@ -36,9 +41,17 @@
     }
   }
   .select {
-    color: c.$primary;
     display: flex;
     flex-direction: column;
     justify-content: center;
+    color: c.$primary;
+    span {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      svg {
+        color: c.$primary;
+      }
+    }
   }
 }

--- a/src/components/CardChoice/CardChoice.scss
+++ b/src/components/CardChoice/CardChoice.scss
@@ -7,6 +7,7 @@
   justify-content: space-between;
   padding: 26px;
   text-decoration: none;
+  transition: background-color 0.1s;
   &.card-choice--bordered {
     border: solid 2px c.$gray-lighter;
     border-top: none;

--- a/src/components/CardChoice/CardChoice.scss
+++ b/src/components/CardChoice/CardChoice.scss
@@ -1,6 +1,7 @@
 @use "../../assets/theme/macbis-colors" as c;
 
 .card-choice {
+  cursor: pointer;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/CardChoice/CardChoice.scss
+++ b/src/components/CardChoice/CardChoice.scss
@@ -1,0 +1,44 @@
+@use "../../assets/theme/macbis-colors" as c;
+
+.card-choice {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 26px;
+  &.card-choice--bordered {
+    border: solid 2px c.$gray-lighter;
+    border-top: none;
+    padding: 24px;
+  }
+  &.card-choice--dark {
+    background-color: c.$gray-lightest;
+  }
+  &:hover {
+    background-color: c.$primary-alt-lightest;
+    border: solid 2px c.$primary-alt-dark;
+    cursor: pointer;
+    padding: 24px;
+    &.card-choice--bordered {
+      margin-top: -2px;
+    }
+  }
+  .content {
+    line-height: 24px;
+    .heading {
+      color: c.$primary;
+      font-weight: 700;
+      font-size: 18px;
+    }
+    .body {
+      color: c.$gray;
+      font-weight: 400;
+      font-size: 16px;
+    }
+  }
+  .select {
+    color: c.$primary;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+}

--- a/src/components/CardChoice/CardChoice.scss
+++ b/src/components/CardChoice/CardChoice.scss
@@ -35,6 +35,7 @@
       color: c.$primary;
       font-weight: 700;
       font-size: 18px;
+      margin: 18px 0;
     }
     .body {
       color: c.$gray;

--- a/src/components/CardChoice/CardChoice.stories.tsx
+++ b/src/components/CardChoice/CardChoice.stories.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { CardChoice } from "./CardChoice";
+
+export default {
+  title: "COMPONENTS/CardChoice/CardChoice",
+  component: CardChoice,
+  argTypes: {},
+  args: {},
+} as ComponentMeta<typeof CardChoice>;
+
+const Template: ComponentStory<typeof CardChoice> = ({ ...rest }) => (
+  <CardChoice />
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/components/CardChoice/CardChoice.stories.tsx
+++ b/src/components/CardChoice/CardChoice.stories.tsx
@@ -7,6 +7,7 @@ export default {
   component: CardChoice,
   args: {
     actionText: "Select",
+    ariaLabel: "A Unique Navigational CardChoice Element",
     bodyText: "Nothing special. Just a standard UI component.",
     headingText: "This is a CardChoice Component",
     href: "",
@@ -15,6 +16,10 @@ export default {
     actionText: {
       description:
         "Optional text prompt to be displayed left of the navigation arrow.",
+    },
+    ariaLabel: {
+      description:
+        'Sets the aria-label for the CardChoice wrapping anchor tag.\n\nIf none is provided, defaults to "Navigation Card for ${headingText}". If no headerText is provided defaults to "Navigation Card."',
     },
     bordered: {
       description:

--- a/src/components/CardChoice/CardChoice.stories.tsx
+++ b/src/components/CardChoice/CardChoice.stories.tsx
@@ -6,9 +6,10 @@ export default {
   title: "COMPONENTS/CardChoice/CardChoice",
   component: CardChoice,
   args: {
-    actionText: "Click Me",
+    actionText: "Select",
     bodyText: "Nothing special. Just a standard UI component.",
     headingText: "This is a CardChoice Component",
+    href: "",
   },
   argTypes: {
     actionText: {
@@ -21,7 +22,8 @@ export default {
     },
     bodyText: { description: "Text to be rendered in the body." },
     children: {
-      description: "Children provided will be rendered below the bodyText.",
+      description:
+        "Children provided will be rendered below the bodyText.\n\n`React.ReactNode`",
     },
     className: {
       description:
@@ -35,8 +37,8 @@ export default {
       description:
         "Bolded heading text displayed at the top of the CardChoice.",
     },
-    href: { description: "href provided to the Link." },
-    onClick: { description: "onClick provided to the Link." },
+    href: { description: "href provided to the Link.", type: "string" },
+    onClick: { description: "onClick provided to the Link.", type: "function" },
   },
 } as ComponentMeta<typeof CardChoice>;
 
@@ -46,3 +48,9 @@ const Template: ComponentStory<typeof CardChoice> = ({ ...rest }) => (
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const Bordered = Template.bind({});
+Bordered.args = { bordered: true };
+
+export const DarkBackground = Template.bind({});
+DarkBackground.args = { darkBG: true };

--- a/src/components/CardChoice/CardChoice.stories.tsx
+++ b/src/components/CardChoice/CardChoice.stories.tsx
@@ -6,11 +6,15 @@ export default {
   title: "COMPONENTS/CardChoice/CardChoice",
   component: CardChoice,
   argTypes: {},
-  args: {},
+  args: {
+    headingText: "This is a CardChoice Component",
+    actionText: "Click Me",
+    children: [<p>Nothing special. Just a standard UI component.</p>],
+  },
 } as ComponentMeta<typeof CardChoice>;
 
 const Template: ComponentStory<typeof CardChoice> = ({ ...rest }) => (
-  <CardChoice />
+  <CardChoice {...rest} />
 );
 
 export const Default = Template.bind({});

--- a/src/components/CardChoice/CardChoice.stories.tsx
+++ b/src/components/CardChoice/CardChoice.stories.tsx
@@ -5,11 +5,38 @@ import { CardChoice } from "./CardChoice";
 export default {
   title: "COMPONENTS/CardChoice/CardChoice",
   component: CardChoice,
-  argTypes: {},
   args: {
-    headingText: "This is a CardChoice Component",
     actionText: "Click Me",
-    children: [<p>Nothing special. Just a standard UI component.</p>],
+    bodyText: "Nothing special. Just a standard UI component.",
+    headingText: "This is a CardChoice Component",
+  },
+  argTypes: {
+    actionText: {
+      description:
+        "Optional text prompt to be displayed left of the navigation arrow.",
+    },
+    bordered: {
+      description:
+        "Renders a border around the CardChoice. Applying borderd on CardChoice will override the CardChoiceGroup.",
+    },
+    bodyText: { description: "Text to be rendered in the body." },
+    children: {
+      description: "Children provided will be rendered below the bodyText.",
+    },
+    className: {
+      description:
+        "Additional classes that can be applied to the root element.",
+    },
+    darkBG: {
+      description:
+        "Renders the CardChoice with a darker background. Applying darkBG on CardChoice will override the CardChoiceGroup. CardChoiceGroup has an option for alternatingBG.",
+    },
+    headingText: {
+      description:
+        "Bolded heading text displayed at the top of the CardChoice.",
+    },
+    href: { description: "href provided to the Link." },
+    onClick: { description: "onClick provided to the Link." },
   },
 } as ComponentMeta<typeof CardChoice>;
 

--- a/src/components/CardChoice/CardChoice.test.tsx
+++ b/src/components/CardChoice/CardChoice.test.tsx
@@ -1,0 +1,195 @@
+import React from "react";
+import { CardChoice } from "./CardChoice";
+import { CardChoiceGroup } from "./CardChoiceGroup";
+import { fireEvent, screen, render } from "../../test-setup";
+
+describe("Tests for the CardChoice component", () => {
+  const headingText = "A CardChoice Component";
+  const bodyText =
+    "This is a standard CardChoice component. It is both an informational and navigational tool.";
+  it("should render with defaults", () => {
+    const { container } = render(
+      <CardChoice headingText={headingText} bodyText={bodyText} />
+    );
+    const component = container.firstElementChild!;
+
+    expect(component.className).toBe("card-choice");
+    expect(component.getAttribute("href")).toBe(null);
+    expect(screen.getByText(headingText)).toBeVisible();
+    expect(screen.getByText(bodyText)).toBeVisible();
+
+    // check no actionText visible
+    const selectSpan =
+      component.getElementsByClassName("select")[0].firstElementChild;
+    expect(selectSpan?.firstElementChild?.tagName).toBe("svg");
+  });
+
+  it("should render body text and children", () => {
+    const { container } = render(
+      <CardChoice headingText={headingText} bodyText={bodyText}>
+        <ul className="test-card-choice-child">
+          <li>Item 1</li>
+          <li>Item 2</li>
+        </ul>
+      </CardChoice>
+    );
+
+    // body should have bodyText and children; bodyText should appear first
+    const body = container.getElementsByClassName("body")[0];
+    expect(body.children.length).toBe(2);
+    expect(body.children[0].innerHTML).toBe(bodyText);
+    expect(body.children[1].className).toBe("test-card-choice-child");
+  });
+
+  it("should have alternate dark background", () => {
+    const { container } = render(<CardChoice darkBG />);
+    const component = container.firstElementChild!;
+    expect(component.className).toBe("card-choice card-choice--dark");
+  });
+
+  it("should have border", () => {
+    const { container } = render(<CardChoice darkBG bordered />);
+    const component = container.firstElementChild!;
+    expect(component.className).toBe(
+      "card-choice card-choice--dark card-choice--bordered"
+    );
+  });
+
+  it("should have a custom className", () => {
+    const { container } = render(
+      <CardChoice darkBG bordered className="test-class" />
+    );
+    const component = container.firstElementChild!;
+    expect(component.className).toBe(
+      "card-choice card-choice--dark card-choice--bordered test-class"
+    );
+  });
+
+  it("should have actionText", () => {
+    const { container } = render(<CardChoice actionText="Click Me" />);
+    const selectSpan =
+      container.getElementsByClassName("select")[0].firstElementChild;
+
+    // should have text and svg image
+    expect(selectSpan?.textContent).toBe("Click Me");
+    expect(selectSpan?.firstElementChild?.tagName).toBe("svg");
+  });
+
+  it("should have onClick event", () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<CardChoice onClick={mockOnClick} />);
+
+    fireEvent.click(container.firstElementChild!);
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});
+
+describe("Tests for the CardChoiceGroup component", () => {
+  it("should render with defaults", () => {
+    const { container } = render(<CardChoiceGroup />);
+    const component = container.firstElementChild!;
+    expect(component.className).toBe("card-choice-group");
+    expect(component.children.length).toBe(1);
+    expect(component.firstElementChild?.tagName).toBe("SPAN");
+    expect(component.firstElementChild?.className).toBe("gradient-cap");
+  });
+
+  it("should render with custom className", () => {
+    const { container } = render(
+      <CardChoiceGroup className="test-ccg-class" />
+    );
+    expect(container.firstElementChild?.className).toBe(
+      "card-choice-group test-ccg-class"
+    );
+  });
+});
+
+describe("Tests for the CardChoice and CardChoiceGroup components", () => {
+  it("should render", () => {
+    const { container } = render(
+      <CardChoiceGroup>
+        <CardChoice />
+        <CardChoice />
+        <CardChoice />
+      </CardChoiceGroup>
+    );
+
+    // 4 children - span and 3 CardChoice
+    expect(container.firstElementChild!.children.length).toBe(4);
+  });
+
+  it("CardChoice elements should have alternating BG color", () => {
+    const { container } = render(
+      <CardChoiceGroup alternatingBG>
+        <CardChoice />
+        <CardChoice />
+        <CardChoice />
+      </CardChoiceGroup>
+    );
+    const cardChoices = [...container.getElementsByClassName("card-choice")];
+    expect(cardChoices.length).toBe(3);
+
+    expect(cardChoices[0].className).toBe("card-choice");
+    expect(cardChoices[1].className).toBe("card-choice card-choice--dark");
+    expect(cardChoices[2].className).toBe("card-choice");
+  });
+
+  it("CardChoice darkBG prop should override CardChoiceGroup alternatingBG", () => {
+    const { container } = render(
+      <CardChoiceGroup alternatingBG>
+        <CardChoice darkBG />
+        <CardChoice darkBG={false} />
+        <CardChoice />
+      </CardChoiceGroup>
+    );
+    const cardChoices = [...container.getElementsByClassName("card-choice")];
+    expect(cardChoices.length).toBe(3);
+
+    expect(cardChoices[0].className).toBe("card-choice card-choice--dark");
+    expect(cardChoices[1].className).toBe("card-choice");
+    expect(cardChoices[2].className).toBe("card-choice");
+  });
+
+  it("all CardChoice elements should have a border", () => {
+    const { container } = render(
+      <CardChoiceGroup bordered>
+        <CardChoice />
+        <CardChoice />
+        <CardChoice />
+      </CardChoiceGroup>
+    );
+    const cardChoices = [...container.getElementsByClassName("card-choice")];
+    expect(cardChoices.length).toBe(3);
+
+    expect(cardChoices[0].className).toBe("card-choice card-choice--bordered");
+    expect(cardChoices[1].className).toBe("card-choice card-choice--bordered");
+    expect(cardChoices[2].className).toBe("card-choice card-choice--bordered");
+  });
+
+  it("CardChoice bordered prop should override CardChoiceGroup bordered", () => {
+    const { container } = render(
+      <CardChoiceGroup bordered>
+        <CardChoice />
+        <CardChoice />
+        <CardChoice bordered={false} />
+      </CardChoiceGroup>
+    );
+    const cardChoices = [...container.getElementsByClassName("card-choice")];
+    expect(cardChoices.length).toBe(3);
+
+    expect(cardChoices[0].className).toBe("card-choice card-choice--bordered");
+    expect(cardChoices[1].className).toBe("card-choice card-choice--bordered");
+    expect(cardChoices[2].className).toBe("card-choice");
+  });
+
+  it("should match snapshot", () => {
+    const { container } = render(
+      <CardChoiceGroup alternatingBG bordered>
+        <CardChoice headingText="CardChoice" bodyText="This is the body." />
+        <CardChoice headingText="CardChoice" bodyText="This is the body." />
+        <CardChoice headingText="CardChoice" bodyText="This is the body." />
+      </CardChoiceGroup>
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/CardChoice/CardChoice.test.tsx
+++ b/src/components/CardChoice/CardChoice.test.tsx
@@ -15,6 +15,9 @@ describe("Tests for the CardChoice component", () => {
 
     expect(component.className).toBe("card-choice");
     expect(component.getAttribute("href")).toBe(null);
+    expect(component.getAttribute("aria-label")).toBe(
+      "Navigation Card for: A CardChoice Component"
+    );
     expect(screen.getByText(headingText)).toBeVisible();
     expect(screen.getByText(bodyText)).toBeVisible();
 
@@ -81,6 +84,22 @@ describe("Tests for the CardChoice component", () => {
 
     fireEvent.click(container.firstElementChild!);
     expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it("should have custom aria-label", () => {
+    const { container } = render(
+      <CardChoice ariaLabel="my aria-label is great" />
+    );
+    expect(container.firstElementChild!.getAttribute("aria-label")).toBe(
+      "my aria-label is great"
+    );
+  });
+
+  it("should have basic aria-label when no details provided", () => {
+    const { container } = render(<CardChoice />);
+    expect(container.firstElementChild!.getAttribute("aria-label")).toBe(
+      "Navigation Card"
+    );
   });
 });
 

--- a/src/components/CardChoice/CardChoice.tsx
+++ b/src/components/CardChoice/CardChoice.tsx
@@ -5,6 +5,7 @@ type IntrinsicElements = JSX.IntrinsicElements["a"];
 
 interface Props extends IntrinsicElements {
   actionText?: string;
+  ariaLabel?: string;
   bodyText?: string;
   bordered?: boolean;
   className?: string;
@@ -16,18 +17,20 @@ interface Props extends IntrinsicElements {
  * CardChoice Component
  *
  * CardChoice is wrapped by an anchor tag. All unspecified props will be provided to the anchor.
- * @param {string}             actionText     Optional text prompt to be displayed left of the navigation arrow.
- * @param {boolean}            bordered       Renders a border around the CardChoice. Applying borderd on CardChoice will override the CardChoiceGroup.
- * @param {string}             bodyText       Text to be rendered in the body.
- * @param {React.ReactNode}    children       Children provided will be rendered below the bodyText.
- * @param {string}             className      Additional classes that can be applied to the root element.
- * @param {boolean}            darkBG         Renders the CardChoice with a darker background. Applying darkBG on CardChoice will override the CardChoiceGroup. CardChoiceGroup has an option for alternatingBG.
- * @param {string}             headingText    Bolded heading text displayed at the top of the CardChoice.
- * @param {string}             href           href provided to the anchor.
- * @param                      onClick        onClick provided to the anchor.
+ * @param {string}             [actionText]     Optional text prompt to be displayed left of the navigation arrow.
+ * @param {string}             [ariaLabel]      Sets the aria-label for the CardChoice wrapping anchor tag. If none is provided, defaults to `Navigation Card for ${headingText}`. If no headerText is provided defaults to "Navigation Card".
+ * @param {boolean}            [bordered]       Renders a border around the CardChoice. Applying borderd on CardChoice will override the CardChoiceGroup.
+ * @param {string}             [bodyText]       Text to be rendered in the body.
+ * @param {React.ReactNode}    [children]       Children provided will be rendered below the bodyText.
+ * @param {string}             [className]      Additional classes that can be applied to the root element.
+ * @param {boolean}            [darkBG]         Renders the CardChoice with a darker background. Applying darkBG on CardChoice will override the CardChoiceGroup. CardChoiceGroup has an option for alternatingBG.
+ * @param {string}             [headingText]    Bolded heading text displayed at the top of the CardChoice.
+ * @param {string}             [href]           href provided to the anchor.
+ * @param {callback}           [onClick]        onClick provided to the anchor.
  */
 export const CardChoice: React.FC<PropsWithChildren<Props>> = ({
   actionText,
+  ariaLabel,
   bodyText,
   bordered,
   children,
@@ -41,17 +44,29 @@ export const CardChoice: React.FC<PropsWithChildren<Props>> = ({
   const classes = `card-choice${darkBG ? " card-choice--dark" : ""}${
     bordered ? " card-choice--bordered" : ""
   }${className ? ` ${className}` : ""}`;
+  ariaLabel =
+    ariaLabel ??
+    (headingText ? `Navigation Card for: ${headingText}` : "Navigation Card");
+
   return (
-    <a {...rest} className={classes} href={href} onClick={onClick}>
+    <a
+      {...rest}
+      aria-label={ariaLabel}
+      className={classes}
+      href={href}
+      onClick={onClick}
+    >
       <div className="content">
-        <p className="heading">{headingText}</p>
+        <h6 className="heading" role="heading" aria-level={6}>
+          {headingText}
+        </h6>
         <span className="body">
           <p>{bodyText}</p>
           {children}
         </span>
       </div>
       <div className="select">
-        <span>
+        <span aria-hidden={true}>
           {actionText}
           <Icon name="navigate_next" />
         </span>

--- a/src/components/CardChoice/CardChoice.tsx
+++ b/src/components/CardChoice/CardChoice.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+type IntrinsicElements = JSX.IntrinsicElements["div"];
+
+interface Props extends IntrinsicElements {
+  bordered?: boolean;
+  darkBG?: boolean;
+}
+
+/**
+ * CardChoice Component
+ * @param {string}    text    Renders the text contained in the component.
+ */
+export const CardChoice: React.FC<Props> = ({ bordered, darkBG, ...rest }) => {
+  return (
+    <div
+      className={`card-choice${darkBG ? " card-choice--dark" : ""}${
+        bordered ? " card-choice--bordered" : ""
+      }`}
+      {...rest}
+    >
+      {/* TODO: Set a max-width for the content so it wraps elegantly */}
+      <div className="content">
+        <p className="heading">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </p>
+        <p className="body">Aliquam pharetra amet vitae sed tempus turpis.</p>
+      </div>
+      <div className="select">Select</div>
+    </div>
+  );
+};

--- a/src/components/CardChoice/CardChoice.tsx
+++ b/src/components/CardChoice/CardChoice.tsx
@@ -1,9 +1,11 @@
 import { Icon } from "components/Icon/Icon";
-import { Link, LinkProps } from "components/Link/Link";
 import React, { PropsWithChildren } from "react";
 
-interface Props extends LinkProps {
+type IntrinsicElements = JSX.IntrinsicElements["a"];
+
+interface Props extends IntrinsicElements {
   actionText?: string;
+  bodyText?: string;
   bordered?: boolean;
   className?: string;
   darkBG?: boolean;
@@ -12,10 +14,21 @@ interface Props extends LinkProps {
 
 /**
  * CardChoice Component
- * @param {string}    text    Renders the text contained in the component.
+ *
+ * CardChoice is wrapped by an anchor tag. All unspecified props will be provided to the anchor.
+ * @param {string}             actionText     Optional text prompt to be displayed left of the navigation arrow.
+ * @param {boolean}            bordered       Renders a border around the CardChoice. Applying borderd on CardChoice will override the CardChoiceGroup.
+ * @param {string}             bodyText       Text to be rendered in the body.
+ * @param {React.ReactNode}    children       Children provided will be rendered below the bodyText.
+ * @param {string}             className      Additional classes that can be applied to the root element.
+ * @param {boolean}            darkBG         Renders the CardChoice with a darker background. Applying darkBG on CardChoice will override the CardChoiceGroup. CardChoiceGroup has an option for alternatingBG.
+ * @param {string}             headingText    Bolded heading text displayed at the top of the CardChoice.
+ * @param {string}             href           href provided to the anchor.
+ * @param                      onClick        onClick provided to the anchor.
  */
 export const CardChoice: React.FC<PropsWithChildren<Props>> = ({
   actionText,
+  bodyText,
   bordered,
   children,
   className,
@@ -29,10 +42,13 @@ export const CardChoice: React.FC<PropsWithChildren<Props>> = ({
     bordered ? " card-choice--bordered" : ""
   }${className ? ` ${className}` : ""}`;
   return (
-    <Link {...rest} className={classes} href={href} onClick={onClick}>
+    <a {...rest} className={classes} href={href} onClick={onClick}>
       <div className="content">
         <p className="heading">{headingText}</p>
-        <span className="body">{children}</span>
+        <span className="body">
+          <p>{bodyText}</p>
+          {children}
+        </span>
       </div>
       <div className="select">
         <span>
@@ -40,6 +56,6 @@ export const CardChoice: React.FC<PropsWithChildren<Props>> = ({
           <Icon name="navigate_next" />
         </span>
       </div>
-    </Link>
+    </a>
   );
 };

--- a/src/components/CardChoice/CardChoice.tsx
+++ b/src/components/CardChoice/CardChoice.tsx
@@ -1,5 +1,5 @@
-import { Icon } from "components/Icon/Icon";
 import React, { PropsWithChildren } from "react";
+import { Icon } from "components/Icon/Icon";
 
 type IntrinsicElements = JSX.IntrinsicElements["a"];
 

--- a/src/components/CardChoice/CardChoice.tsx
+++ b/src/components/CardChoice/CardChoice.tsx
@@ -1,32 +1,45 @@
-import React from "react";
+import { Icon } from "components/Icon/Icon";
+import { Link, LinkProps } from "components/Link/Link";
+import React, { PropsWithChildren } from "react";
 
-type IntrinsicElements = JSX.IntrinsicElements["div"];
-
-interface Props extends IntrinsicElements {
+interface Props extends LinkProps {
+  actionText?: string;
   bordered?: boolean;
+  className?: string;
   darkBG?: boolean;
+  headingText?: string;
 }
 
 /**
  * CardChoice Component
  * @param {string}    text    Renders the text contained in the component.
  */
-export const CardChoice: React.FC<Props> = ({ bordered, darkBG, ...rest }) => {
+export const CardChoice: React.FC<PropsWithChildren<Props>> = ({
+  actionText,
+  bordered,
+  children,
+  className,
+  darkBG,
+  headingText,
+  href,
+  onClick,
+  ...rest
+}) => {
+  const classes = `card-choice${darkBG ? " card-choice--dark" : ""}${
+    bordered ? " card-choice--bordered" : ""
+  }${className ? ` ${className}` : ""}`;
   return (
-    <div
-      className={`card-choice${darkBG ? " card-choice--dark" : ""}${
-        bordered ? " card-choice--bordered" : ""
-      }`}
-      {...rest}
-    >
-      {/* TODO: Set a max-width for the content so it wraps elegantly */}
+    <Link {...rest} className={classes} href={href} onClick={onClick}>
       <div className="content">
-        <p className="heading">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </p>
-        <p className="body">Aliquam pharetra amet vitae sed tempus turpis.</p>
+        <p className="heading">{headingText}</p>
+        <span className="body">{children}</span>
       </div>
-      <div className="select">Select</div>
-    </div>
+      <div className="select">
+        <span>
+          {actionText}
+          <Icon name="navigate_next" />
+        </span>
+      </div>
+    </Link>
   );
 };

--- a/src/components/CardChoice/CardChoiceGroup.scss
+++ b/src/components/CardChoice/CardChoiceGroup.scss
@@ -1,13 +1,15 @@
 @use "../../assets/theme/macbis-colors" as c;
 .card-choice-group {
+  border-radius: 4px;
+
   .gradient-cap {
     background: linear-gradient(to right, c.$primary, c.$primary-alt);
     border-radius: 4px 4px 0 0;
-    display: inline-block;
+    display: block;
     height: 8px;
     width: 100%;
-    margin: 0;
-    position: relative;
-    top: 4px;
+  }
+  :last-child {
+    border-radius: 0 0 4px 4px;
   }
 }

--- a/src/components/CardChoice/CardChoiceGroup.scss
+++ b/src/components/CardChoice/CardChoiceGroup.scss
@@ -1,0 +1,13 @@
+@use "../../assets/theme/macbis-colors" as c;
+.card-choice-group {
+  .gradient-cap {
+    background: linear-gradient(to right, c.$primary, c.$primary-alt);
+    border-radius: 4px 4px 0 0;
+    display: inline-block;
+    height: 8px;
+    width: 100%;
+    margin: 0;
+    position: relative;
+    top: 4px;
+  }
+}

--- a/src/components/CardChoice/CardChoiceGroup.stories.tsx
+++ b/src/components/CardChoice/CardChoiceGroup.stories.tsx
@@ -3,21 +3,51 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { CardChoice } from "./CardChoice";
 import { CardChoiceGroup } from "./CardChoiceGroup";
 
+const children = [
+  <CardChoice
+    actionText="Select"
+    href=""
+    key="card-1"
+    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+  >
+    <p>Aliquam pharetra amet vitae sed tempus turpis.</p>
+  </CardChoice>,
+  <CardChoice
+    href=""
+    key="card-2"
+    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+  >
+    <p>Aliquam pharetra amet vitae sed tempus turpis.</p>
+  </CardChoice>,
+  <CardChoice
+    actionText="Select"
+    href=""
+    key="card-3"
+    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+  >
+    <p>Aliquam pharetra amet vitae sed tempus turpis.</p>
+  </CardChoice>,
+  <CardChoice
+    actionText="Select"
+    href=""
+    key="card-4"
+    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+  >
+    <p>Aliquam pharetra amet vitae sed tempus turpis.</p>
+  </CardChoice>,
+];
+
 export default {
   title: "COMPONENTS/CardChoice/CardChoiceGroup",
   component: CardChoice,
   argTypes: {},
-  args: {},
+  args: {
+    children,
+  },
 } as ComponentMeta<typeof CardChoiceGroup>;
 
 const Template: ComponentStory<typeof CardChoiceGroup> = ({ ...rest }) => (
-  <CardChoiceGroup>
-    <CardChoice bordered />
-    <CardChoice bordered />
-    <CardChoice />
-    <CardChoice darkBG />
-    <CardChoice />
-  </CardChoiceGroup>
+  <CardChoiceGroup {...rest} />
 );
 
 export const Default = Template.bind({});

--- a/src/components/CardChoice/CardChoiceGroup.stories.tsx
+++ b/src/components/CardChoice/CardChoiceGroup.stories.tsx
@@ -44,10 +44,23 @@ const children = [
 
 export default {
   title: "COMPONENTS/CardChoice/CardChoiceGroup",
-  component: CardChoice,
-  argTypes: {},
+  component: CardChoiceGroup,
   args: {
     children,
+  },
+  argTypes: {
+    alternatingBG: {
+      description:
+        "`CardChoice` children are displayed with an alternating background color. The darkBG property on an individual CardChoice will override this property.",
+    },
+    bordered: {
+      description:
+        "All `CardChoice` children are displayed with a gray border. The bordered property on an individual CardChoice will override this property.",
+    },
+    children: {
+      description: "`CardChoice` children to be rendered.",
+      control: false,
+    },
   },
 } as ComponentMeta<typeof CardChoiceGroup>;
 
@@ -57,3 +70,13 @@ const Template: ComponentStory<typeof CardChoiceGroup> = ({ ...rest }) => (
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const Bordered = Template.bind({});
+Bordered.args = {
+  bordered: true,
+};
+
+export const Alternating = Template.bind({});
+Alternating.args = {
+  alternatingBG: true,
+};

--- a/src/components/CardChoice/CardChoiceGroup.stories.tsx
+++ b/src/components/CardChoice/CardChoiceGroup.stories.tsx
@@ -6,32 +6,37 @@ import { CardChoiceGroup } from "./CardChoiceGroup";
 const children = [
   <CardChoice
     actionText="Select"
+    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     href=""
     key="card-1"
-    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
   >
     <p>Aliquam pharetra amet vitae sed tempus turpis.</p>
   </CardChoice>,
   <CardChoice
+    actionText="Click Me"
+    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     href=""
     key="card-2"
-    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
   >
     <p>Aliquam pharetra amet vitae sed tempus turpis.</p>
+    <p>Praesent sem mauris, sollicitudin ut interdum nec, auctor a nunc.</p>
+    <ul>
+      <li>Item 1</li>
+      <li>Item 2</li>
+    </ul>
   </CardChoice>,
   <CardChoice
-    actionText="Select"
+    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     href=""
     key="card-3"
-    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
   >
     <p>Aliquam pharetra amet vitae sed tempus turpis.</p>
   </CardChoice>,
   <CardChoice
     actionText="Select"
+    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     href=""
     key="card-4"
-    headingText="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
   >
     <p>Aliquam pharetra amet vitae sed tempus turpis.</p>
   </CardChoice>,

--- a/src/components/CardChoice/CardChoiceGroup.stories.tsx
+++ b/src/components/CardChoice/CardChoiceGroup.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { CardChoice } from "./CardChoice";
+import { CardChoiceGroup } from "./CardChoiceGroup";
+
+export default {
+  title: "COMPONENTS/CardChoice/CardChoiceGroup",
+  component: CardChoice,
+  argTypes: {},
+  args: {},
+} as ComponentMeta<typeof CardChoiceGroup>;
+
+const Template: ComponentStory<typeof CardChoiceGroup> = ({ ...rest }) => (
+  <CardChoiceGroup>
+    <CardChoice bordered />
+    <CardChoice bordered />
+    <CardChoice />
+    <CardChoice darkBG />
+    <CardChoice />
+  </CardChoiceGroup>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/components/CardChoice/CardChoiceGroup.tsx
+++ b/src/components/CardChoice/CardChoiceGroup.tsx
@@ -9,9 +9,9 @@ interface Props extends IntrinsicElements {
 
 /**
  * CardChoiceGroup Component
- * @param {boolean}            alternatingBG    CardChoice children are displayed with an alternating background color. The darkBG property on an individual CardChoice will override this property.
- * @param {boolean}            bordered         All CardChoice children are displayed with a gray border. The bordered property on an individual CardChoice will override this property.
- * @param {React.ReactNode}    children         CardChoice children to be rendered.
+ * @param {boolean}            [alternatingBG]    CardChoice children are displayed with an alternating background color. The darkBG property on an individual CardChoice will override this property.
+ * @param {boolean}            [bordered]         All CardChoice children are displayed with a gray border. The bordered property on an individual CardChoice will override this property.
+ * @param {React.ReactNode}    [children]         CardChoice children to be rendered.
  */
 export const CardChoiceGroup: React.FC<PropsWithChildren<Props>> = ({
   alternatingBG = false,

--- a/src/components/CardChoice/CardChoiceGroup.tsx
+++ b/src/components/CardChoice/CardChoiceGroup.tsx
@@ -9,7 +9,9 @@ interface Props extends IntrinsicElements {
 
 /**
  * CardChoiceGroup Component
- * @param {string}    text    Renders the text contained in the component.
+ * @param {boolean}            alternatingBG    CardChoice children are displayed with an alternating background color. The darkBG property on an individual CardChoice will override this property.
+ * @param {boolean}            bordered         All CardChoice children are displayed with a gray border. The bordered property on an individual CardChoice will override this property.
+ * @param {React.ReactNode}    children         CardChoice children to be rendered.
  */
 export const CardChoiceGroup: React.FC<PropsWithChildren<Props>> = ({
   alternatingBG = false,

--- a/src/components/CardChoice/CardChoiceGroup.tsx
+++ b/src/components/CardChoice/CardChoiceGroup.tsx
@@ -17,11 +17,15 @@ export const CardChoiceGroup: React.FC<PropsWithChildren<Props>> = ({
   alternatingBG = false,
   bordered = false,
   children,
+  className,
   ...rest
 }) => {
   const arrayChildren = Children.toArray(children);
   return (
-    <div className="card-choice-group" {...rest}>
+    <div
+      className={`card-choice-group${className ? ` ${className}` : ""}`}
+      {...rest}
+    >
       <span className="gradient-cap"></span>
       {Children.map(arrayChildren, (child, idx) => {
         if (React.isValidElement(child)) {

--- a/src/components/CardChoice/CardChoiceGroup.tsx
+++ b/src/components/CardChoice/CardChoiceGroup.tsx
@@ -1,21 +1,34 @@
-import React, { PropsWithChildren } from "react";
+import React, { Children, PropsWithChildren } from "react";
 
 type IntrinsicElements = JSX.IntrinsicElements["div"];
 
-interface Props extends IntrinsicElements {}
+interface Props extends IntrinsicElements {
+  alternatingBG?: boolean;
+  bordered?: boolean;
+}
 
 /**
  * CardChoiceGroup Component
  * @param {string}    text    Renders the text contained in the component.
  */
 export const CardChoiceGroup: React.FC<PropsWithChildren<Props>> = ({
+  alternatingBG = false,
+  bordered = false,
   children,
   ...rest
 }) => {
+  const arrayChildren = Children.toArray(children);
   return (
     <div className="card-choice-group" {...rest}>
       <span className="gradient-cap"></span>
-      {children}
+      {Children.map(arrayChildren, (child, idx) => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, {
+            bordered: child.props.bordered ?? bordered,
+            darkBG: child.props.darkBG ?? (alternatingBG && idx % 2),
+          });
+        }
+      })}
     </div>
   );
 };

--- a/src/components/CardChoice/CardChoiceGroup.tsx
+++ b/src/components/CardChoice/CardChoiceGroup.tsx
@@ -1,0 +1,21 @@
+import React, { PropsWithChildren } from "react";
+
+type IntrinsicElements = JSX.IntrinsicElements["div"];
+
+interface Props extends IntrinsicElements {}
+
+/**
+ * CardChoiceGroup Component
+ * @param {string}    text    Renders the text contained in the component.
+ */
+export const CardChoiceGroup: React.FC<PropsWithChildren<Props>> = ({
+  children,
+  ...rest
+}) => {
+  return (
+    <div className="card-choice-group" {...rest}>
+      <span className="gradient-cap"></span>
+      {children}
+    </div>
+  );
+};

--- a/src/components/CardChoice/__snapshots__/CardChoice.test.tsx.snap
+++ b/src/components/CardChoice/__snapshots__/CardChoice.test.tsx.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tests for the CardChoice and CardChoiceGroup components should match snapshot 1`] = `
+<div>
+  <div
+    class="card-choice-group"
+  >
+    <span
+      class="gradient-cap"
+    />
+    <a
+      class="card-choice card-choice--bordered"
+    >
+      <div
+        class="content"
+      >
+        <p
+          class="heading"
+        >
+          CardChoice
+        </p>
+        <span
+          class="body"
+        >
+          <p>
+            This is the body.
+          </p>
+        </span>
+      </div>
+      <div
+        class="select"
+      >
+        <span>
+          <svg
+            aria-hidden="true"
+            aria-label="navigate next icon"
+            class="usa-icon--size-3"
+            color="black"
+            fill="currentColor"
+            role="img"
+          >
+            <use
+              href="sprite.svg#navigate_next"
+            />
+          </svg>
+        </span>
+      </div>
+    </a>
+    <a
+      class="card-choice card-choice--dark card-choice--bordered"
+    >
+      <div
+        class="content"
+      >
+        <p
+          class="heading"
+        >
+          CardChoice
+        </p>
+        <span
+          class="body"
+        >
+          <p>
+            This is the body.
+          </p>
+        </span>
+      </div>
+      <div
+        class="select"
+      >
+        <span>
+          <svg
+            aria-hidden="true"
+            aria-label="navigate next icon"
+            class="usa-icon--size-3"
+            color="black"
+            fill="currentColor"
+            role="img"
+          >
+            <use
+              href="sprite.svg#navigate_next"
+            />
+          </svg>
+        </span>
+      </div>
+    </a>
+    <a
+      class="card-choice card-choice--bordered"
+    >
+      <div
+        class="content"
+      >
+        <p
+          class="heading"
+        >
+          CardChoice
+        </p>
+        <span
+          class="body"
+        >
+          <p>
+            This is the body.
+          </p>
+        </span>
+      </div>
+      <div
+        class="select"
+      >
+        <span>
+          <svg
+            aria-hidden="true"
+            aria-label="navigate next icon"
+            class="usa-icon--size-3"
+            color="black"
+            fill="currentColor"
+            role="img"
+          >
+            <use
+              href="sprite.svg#navigate_next"
+            />
+          </svg>
+        </span>
+      </div>
+    </a>
+  </div>
+</div>
+`;

--- a/src/components/CardChoice/__snapshots__/CardChoice.test.tsx.snap
+++ b/src/components/CardChoice/__snapshots__/CardChoice.test.tsx.snap
@@ -9,16 +9,19 @@ exports[`Tests for the CardChoice and CardChoiceGroup components should match sn
       class="gradient-cap"
     />
     <a
+      aria-label="Navigation Card for: CardChoice"
       class="card-choice card-choice--bordered"
     >
       <div
         class="content"
       >
-        <p
+        <h6
+          aria-level="6"
           class="heading"
+          role="heading"
         >
           CardChoice
-        </p>
+        </h6>
         <span
           class="body"
         >
@@ -30,7 +33,9 @@ exports[`Tests for the CardChoice and CardChoiceGroup components should match sn
       <div
         class="select"
       >
-        <span>
+        <span
+          aria-hidden="true"
+        >
           <svg
             aria-hidden="true"
             aria-label="navigate next icon"
@@ -47,16 +52,19 @@ exports[`Tests for the CardChoice and CardChoiceGroup components should match sn
       </div>
     </a>
     <a
+      aria-label="Navigation Card for: CardChoice"
       class="card-choice card-choice--dark card-choice--bordered"
     >
       <div
         class="content"
       >
-        <p
+        <h6
+          aria-level="6"
           class="heading"
+          role="heading"
         >
           CardChoice
-        </p>
+        </h6>
         <span
           class="body"
         >
@@ -68,7 +76,9 @@ exports[`Tests for the CardChoice and CardChoiceGroup components should match sn
       <div
         class="select"
       >
-        <span>
+        <span
+          aria-hidden="true"
+        >
           <svg
             aria-hidden="true"
             aria-label="navigate next icon"
@@ -85,16 +95,19 @@ exports[`Tests for the CardChoice and CardChoiceGroup components should match sn
       </div>
     </a>
     <a
+      aria-label="Navigation Card for: CardChoice"
       class="card-choice card-choice--bordered"
     >
       <div
         class="content"
       >
-        <p
+        <h6
+          aria-level="6"
           class="heading"
+          role="heading"
         >
           CardChoice
-        </p>
+        </h6>
         <span
           class="body"
         >
@@ -106,7 +119,9 @@ exports[`Tests for the CardChoice and CardChoiceGroup components should match sn
       <div
         class="select"
       >
-        <span>
+        <span
+          aria-hidden="true"
+        >
           <svg
             aria-hidden="true"
             aria-label="navigate next icon"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,8 @@ import "./assets/theme/styles.scss";
 import { ActionsMenu } from "./components/Header/ActionsMenu";
 import { Button } from "./components/Button/Button";
 import { Card } from "./components/Card/Card";
+import { CardChoice } from "./components/CardChoice/CardChoice";
+import { CardChoiceGroup } from "./components/CardChoice/CardChoiceGroup";
 import { Checkbox } from "./components/Checkbox/Checkbox";
 import { Dropdown } from "./components/Dropdown/Dropdown";
 import { Footer } from "./components/Footer/Footer";
@@ -22,6 +24,8 @@ export {
   ActionsMenu,
   Button,
   Card,
+  CardChoice,
+  CardChoiceGroup,
   Checkbox,
   Dropdown,
   Footer,


### PR DESCRIPTION
## Purpose

Create a CardChoice component.

## Type of Request

feature

## Approach

Creates 2 components `CardChoice` and `CardChoiceGroup`. The majority of the work is in the `CardChoice` while `CardChoiceGroup` serves as a wrapper to relate multiple `CardChoice` children. All style variable controls can be adjusted at the wrapper or the child level. Child settings will override the wrapper (e.g. if the wrapper is trying to set an alternating background-color, an instruction on the child will override whatever the wrapper attempts to do).

This is the first component I have built on this project that does not rely on USWDS.js at all. Tried to be exhaustive but not excessive with unit testing. Tests all props on both components, tests components in combination with each other, includes a snapshot at the end for styling.

## Assorted Notes/Considerations

The child does not need the wrapper, but it may be useful for organization. A user could fairly simply create their own wrapper for the children if they wanted. 

Not at all mission critical, but I did not come up with a "good" way to test the hover state in Jest.

#### Pull Request Creator Checklist

- [X] It is documented what type of request this is.
- [X] There is a detailed description for the purpose of this PR.
- [X] This PR is in line with the intention of this Project
