### PR TITLE
Revert "chore(deps-dev): bump rollup from 2.79.1 to 3.1.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "react": "^18.2.0",
         "react-calendar": "^3.9.0",
         "react-dom": "^18.2.0",
-        "rollup": "^3.1.0",
+        "rollup": "^2.77.1",
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-import-css": "^3.0.3",
         "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -29817,16 +29817,15 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.1.0.tgz",
-      "integrity": "sha512-GEvr+COcXicr4nuih6mpt2Eydq5lZ72z0RrKx1H4/Q2ouT34OHrIIJ9OUj2sZqUhq7QL8Hp8Q8BoWbjL/6ccRQ==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -57723,9 +57722,9 @@
       }
     },
     "rollup": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.1.0.tgz",
-      "integrity": "sha512-GEvr+COcXicr4nuih6mpt2Eydq5lZ72z0RrKx1H4/Q2ouT34OHrIIJ9OUj2sZqUhq7QL8Hp8Q8BoWbjL/6ccRQ==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react": "^18.2.0",
     "react-calendar": "^3.9.0",
     "react-dom": "^18.2.0",
-    "rollup": "^3.1.0",
+    "rollup": "^2.77.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-import-css": "^3.0.3",
     "rollup-plugin-peer-deps-external": "^2.2.4",


### PR DESCRIPTION
Reverts CMSgov/macpro-ux-lib#150