### PR TITLE
Revert "chore(deps-dev): bump rollup from 2.79.1 to 3.2.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "postcss": "^8.4.16",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "rollup": "^3.2.3",
+        "rollup": "^2.77.1",
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-import-css": "^3.0.3",
         "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -29810,16 +29810,15 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
-      "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -57669,9 +57668,9 @@
       }
     },
     "rollup": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
-      "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "postcss": "^8.4.16",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rollup": "^3.2.3",
+    "rollup": "^2.77.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-import-css": "^3.0.3",
     "rollup-plugin-peer-deps-external": "^2.2.4",


### PR DESCRIPTION
Reverts CMSgov/macpro-ux-lib#164